### PR TITLE
Fix intendation and remove unnecessary check

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -19,7 +19,6 @@ func _physics_process(delta):
 		direction += transform.basis.x
 	direction = direction.normalized()
 	
-	if direction != Vector3():
-		if is_network_master():
-			move_and_slide(direction * speed, Vector3.UP)
+	if is_network_master():
+		move_and_slide(direction * speed, Vector3.UP)
 		rpc_unreliable("_set_position", global_transform.origin)


### PR DESCRIPTION
As Danyl Bekhoucha commented on your Youtube tutorial:

> You have jittery movements because you haven't indented the rpc call, the player that aren't network masters send the transforms of the other players too.